### PR TITLE
fix: pageOffset parameter of pinList function

### DIFF
--- a/src/download-cids.js
+++ b/src/download-cids.js
@@ -93,7 +93,7 @@ const { log, table: logTable, error } = console;
       }
       cidMappings = { ...cidMappings, ...mapping };
       hasMoreResults = count >= MAX_PAGE_LIMIT;
-      pageOffset += 1;
+      pageOffset += count;
       totalCount += count;
     }
     if (totalCount <= 0) {


### PR DESCRIPTION
Pinata's API uses `pageOffset` parameter as data offset, not page offset.

We can confirm it through the requests below:
- https://api.pinata.cloud/data/pinList?includeCount=false&pageLimit=20&pageOffset=0
- https://api.pinata.cloud/data/pinList?includeCount=false&pageLimit=20&pageOffset=1
- https://api.pinata.cloud/data/pinList?includeCount=false&pageLimit=20&pageOffset=20